### PR TITLE
Use https for fallback (public) pypi

### DIFF
--- a/cloudpypi/main.py
+++ b/cloudpypi/main.py
@@ -21,7 +21,7 @@ JINJA_ENVIRONMENT = jinja2.Environment(
 
 class configuration(object):
     def __init__(self):
-        self.fallback_url = "http://pypi.python.org/simple"
+        self.fallback_url = "https://pypi.python.org/simple"
         self.bucket = "packages"
         self.redirect_to_fallback = True
         self.overwrite = False


### PR DESCRIPTION
- Public pypi server recently began requiring https

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vendasta/cloudpypi/1)
<!-- Reviewable:end -->
